### PR TITLE
allow 0 or 1 space after `>` for callout suggestion

### DIFF
--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -136,7 +136,8 @@ export class CalloutSuggest extends BracketSuggest {
 	constructor(app: App, plugin: Plugin, csv: string) {
 		super(app, plugin, {
 			suggestions: csv.split(",").map((str) => str.trim()),
-			triggerRegex: /^\s*> \[!(\w*)$/,
+			// allow 0/1 space before the `[!` - https://github.com/blorbb/obsidian-blockier/issues/5
+			triggerRegex: /^\s*> ?\[!(\w*)$/,
 			suggestionClass: "blockier-callout-suggestion",
 			renderMarkdown: (suggestion) => `> [!${suggestion}]`,
 		});


### PR DESCRIPTION
fixes #5 